### PR TITLE
Fixes Toolbar render dependent on weather data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2018-06-14
+### Fixed
+- Toolbar does not depend on weather data being fetched and always renders.
+
 ## [1.3.0] - 2018-06-14
 ### Added
 - Notifies the user when a new version is available.
@@ -42,6 +46,7 @@ correctly the row title if no subtitle is provided.
   - Display forecast for the next three days (min, max and condition icon)
   - Settings page with _about_ section
 
+[1.3.1]: https://github.com/matt-block/progressive-weather/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/matt-block/progressive-weather/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/matt-block/progressive-weather/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/matt-block/progressive-weather/compare/v1.1.1...v1.2.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "progressive-weather",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A progressive web application build with React for weather forecast.",
   "keywords": [
     "weather",

--- a/src/components/Toolbar/Toolbar.jsx
+++ b/src/components/Toolbar/Toolbar.jsx
@@ -15,8 +15,6 @@ import { ToolbarShell, ToolbarTitle, ToolbarNavigation, ToolbarSettings } from '
 import { NotificationDot, SettingsIcon, BackIcon } from '../Icons'
 
 function Toolbar(props) {
-  if (!props.currentData) { return null }
-
   const backIcon = (
     <button onClick={props.goBack}>
       <BackIcon />
@@ -31,7 +29,7 @@ function Toolbar(props) {
     </button>
   )
 
-  let title = props.currentData.locationName
+  let title = props.currentData ? props.currentData.locationName : ''
   if (props.currentPath === '/settings') { title = 'Settings' }
   if (props.currentPath === '/licenses') { title = 'Licenses' }
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -19,7 +19,7 @@ export const API_KEY = process.env.REACT_APP_OPENWEATHERMAP_KEY
  *
  * @see {@link https://semver.org/}
  */
-export const APP_VERSION = '1.3.0'
+export const APP_VERSION = '1.3.1'
 
 /**
  * URL of the application repository.


### PR DESCRIPTION
This PR fixes an issue where the `Toolbar` component would render `null` if there is no weather data. This behaviour was initially set because on the main route the component needs the location name from the weather data to display it.

However, this is an issue because it's navigation buttons are not available while data is being fetched. Also, when the app is started from other routes like `/settings` there is no need for remote data to be fetched, so pages would render immediately and as expected minus the toolbar which will render _eventually_.