### PR TITLE
Disables zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.5.4] - 2018-06-20
+### Changed
+- Disables zoom.
+
 ## [1.5.3] - 2018-06-19
 ### Fixed
 - iOS icon not appearing when adding the app to Home.
@@ -77,6 +81,7 @@ correctly the row title if no subtitle is provided.
   - Display forecast for the next three days (min, max and condition icon)
   - Settings page with _about_ section
 
+[1.5.4]: https://github.com/matt-block/progressive-weather/compare/v1.5.3...v1.5.4
 [1.5.3]: https://github.com/matt-block/progressive-weather/compare/v1.5.2...v1.5.3
 [1.5.2]: https://github.com/matt-block/progressive-weather/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/matt-block/progressive-weather/compare/v1.5.0...v1.5.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "progressive-weather",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "A progressive web application build with React for weather forecast.",
   "keywords": [
     "weather",

--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <meta name="theme-color" content="#141518">
     <!--
       manifest.json provides metadata used when your web app is added to the

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -24,7 +24,7 @@ export const API_URL = 'https://openweathermap.org/'
  *
  * @see {@link https://semver.org/}
  */
-export const APP_VERSION = '1.5.3'
+export const APP_VERSION = '1.5.4'
 
 /**
  * URL of the application repository.


### PR DESCRIPTION
By adding the property `user-scalable=no` in the `viewport` meta tag, user zoom is disabled. This behaviour is desired so that the application resembles more a native mobile application.

This does not affect much accessibility as the application is designed to be responsive and does react well to font and UI OS scaling settings.